### PR TITLE
Use version 1.4.2 instead.

### DIFF
--- a/mosquitto-dev/Dockerfile
+++ b/mosquitto-dev/Dockerfile
@@ -3,10 +3,13 @@ FROM sanji/base-dev:wheezy
 MAINTAINER Zack YL Shih <zackyl.shih@moxa.com>
 
 ADD ./ /home
-RUN apt-get update && \
-    apt-get install -y libc-ares2 && \
-    dpkg -i /home/amd64/libmosquitto1_1.3.5-0mosquitto1_amd64.deb && \
-    dpkg -i /home/libmosquitto-dev_1.3.5-0mosquitto1_all.deb && \
-    apt-get install -y wget && \
-    apt-get install -y libjansson-dev && \
+RUN apt-get update && apt-get install -y wget && \
+    wget -O - http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key | \
+    apt-key add - && \
+    wget -O /etc/apt/sources.list.d/mosquitto-repo.list \
+        http://repo.mosquitto.org/debian/mosquitto-wheezy.list && \
+    wget http://repo.mosquitto.org/debian/pool/main/m/mosquitto/libmosquitto-dev_1.4.2-0mosquitto1~nows_all.deb && \
+    apt-get update && \
+    apt-get install -y libjansson-dev libmosquitto1 && \
+    dpkg -i libmosquitto-dev_1.4.2-0mosquitto1~nows_all.deb && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
On armhf, libmosquitto-dev's version is wrong (only 1.4.0 can be
installed but no libmosquitto1-1.4.0).
